### PR TITLE
Ensure alkindix.com uses root domain

### DIFF
--- a/api/subscribe.js
+++ b/api/subscribe.js
@@ -7,7 +7,6 @@ const hits = new Map();              // ip -> { count, resetAt }
 
 const allowedOrigins = new Set([
   'https://alkindix.com',
-  'https://www.alkindix.com',
   // Add your Vercel preview/prod URLs if you use them directly:
   // 'https://<your-project>.vercel.app'
 ]);

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <meta name="format-detection" content="telephone=no, address=no, email=no" />
   <meta name="robots" content="index,follow,max-image-preview:large" />
-  <link rel="canonical" href="https://www.alkindix.com/" />
+  <link rel="canonical" href="https://alkindix.com/" />
 
   <!-- Icons / Manifest -->
   <link rel="icon" href="/favicon.ico" sizes="any" />
@@ -40,7 +40,7 @@
   <meta property="og:title" content="AlkindiX — Building Cognition Infrastructure" />
   <meta property="og:description" content="Symbolic AI × Quantum Reasoning × Mathematics. Gateway to ProofX, ProjectX, and essays." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://www.alkindix.com/" />
+  <meta property="og:url" content="https://alkindix.com/" />
   <meta property="og:site_name" content="AlkindiX" />
   <meta property="og:locale" content="en_GB" />
   <!-- Add when /og.png exists:
@@ -267,7 +267,7 @@
     "@context": "https://schema.org",
     "@type": "Person",
     "name": "Alkindi",
-    "url": "https://www.alkindix.com",
+    "url": "https://alkindix.com",
     "jobTitle": "Founder, ProofX; Engineering Student, UCL",
     "affiliation": { "@type": "CollegeOrUniversity", "name": "University College London" },
     "sameAs": [
@@ -282,10 +282,10 @@
     "@context": "https://schema.org",
     "@type": "WebSite",
     "name": "AlkindiX",
-    "url": "https://www.alkindix.com/",
+    "url": "https://alkindix.com/",
     "potentialAction": {
       "@type": "SearchAction",
-      "target": "https://www.alkindix.com/?q={search_term_string}",
+      "target": "https://alkindix.com/?q={search_term_string}",
       "query-input": "required name=search_term_string"
     }
   }

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,15 @@
     { "source": "/", "destination": "/index.html" }
   ],
 
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "has": [{ "type": "host", "value": "www.alkindix.com" }],
+      "destination": "https://alkindix.com/$1",
+      "permanent": true
+    }
+  ],
+
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- Replace `www.alkindix.com` references with `alkindix.com` in HTML metadata and structured data
- Allow API requests only from `alkindix.com`
- Redirect `www.alkindix.com` to the bare domain via Vercel config

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af675776e483288d234db4ceb916f4