### PR TITLE
Add offline banner and service worker caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
   <noscript><style>.no-js .menu-btn{display:none}</style></noscript>
 </head>
 <body>
+  <div id="offlineBanner" class="offline-banner" hidden role="status" aria-live="polite">You're offline.</div>
   <a href="#main" class="skip" aria-label="Skip to main content">Skip to content</a>
 
   <!-- Header / Global Nav -->

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en-GB" dir="ltr" data-theme="auto">
+<head>
+  <meta charset="utf-8" />
+  <title>Offline — AlkindiX</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <link rel="stylesheet" href="/styles.css" />
+  <style>
+    body {
+      display:flex; align-items:center; justify-content:center;
+      min-height:100vh; text-align:center; padding: var(--space-lg);
+      background: var(--bg);
+      animation: fadeIn .6s var(--ease) both;
+    }
+    .offline {
+      max-width: 640px; display:grid; gap: var(--space-md);
+      animation: floatUp .8s var(--ease) both;
+    }
+    .offline h1 {
+      font-size: clamp(4rem, 14vw, 7rem);
+      margin: 0;
+      font-weight: 900;
+      line-height: 1;
+      background: var(--grad-accent);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .offline p {
+      margin: 0;
+      font-size: 1.2rem;
+      color: var(--muted);
+    }
+    .actions {
+      display:flex; justify-content:center; gap: var(--space-sm); flex-wrap:wrap;
+      margin-top: var(--space-sm);
+    }
+    .pill {
+      margin-top: var(--space-md);
+      justify-content:center;
+    }
+    @keyframes floatUp { from { opacity:0; transform:translateY(12px);} to { opacity:1; transform:translateY(0);} }
+  </style>
+</head>
+<body>
+  <main class="offline" role="main" aria-labelledby="title">
+    <h1 id="title">Offline</h1>
+    <p>You're offline. Check your connection and try again.</p>
+    <div class="actions" role="group" aria-label="Actions">
+      <a class="btn accent" href="/">Reload</a>
+    </div>
+    <div class="pill">AlkindiX — Building Cognition Infrastructure</div>
+  </main>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -293,6 +293,20 @@ footer nav a { font-weight: 600; opacity: .85; }            /* enhanced */
 footer nav a:hover { opacity: 1; color: var(--accent); }    /* enhanced */
 
 /* --------------------------------------------
+   Offline Banner
+--------------------------------------------- */
+.offline-banner {
+  position: fixed;
+  inset: auto 0 0 0;
+  background: var(--danger);
+  color: #fff;
+  text-align: center;
+  padding: var(--space-xs) var(--gutter);
+  font-weight: 600;
+  z-index: 1000;
+}
+
+/* --------------------------------------------
    Focus / A11y
 --------------------------------------------- */
 .focus-ring { outline: none; box-shadow: 0 0 0 0 transparent; }


### PR DESCRIPTION
## Summary
- add offline status banner to homepage
- style banner and implement basic offline caching in service worker
- provide dedicated offline fallback page and cache assets without redirects

## Testing
- `node --check public/sw.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68af686d7b1883289f04ea7360317b47