### PR TITLE
Add informational pages and update navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en-GB" dir="ltr" class="no-js" data-theme="auto">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>About — AlkindiX</title>
+  <meta name="description" content="Learn about AlkindiX and its mission to build cognition infrastructure." />
+  <link rel="preload" href="/styles.css" as="style" />
+  <link rel="stylesheet" href="/styles.css" media="all" />
+  <link rel="preload" href="/main.js" as="script" />
+</head>
+<body>
+  <div id="offlineBanner" class="offline-banner" hidden role="status" aria-live="polite">You're offline.</div>
+  <a href="#main" class="skip" aria-label="Skip to main content">Skip to content</a>
+  <header class="header" role="banner">
+    <div class="container nav">
+      <a href="/" class="brand focus-ring" aria-label="AlkindiX home">
+        <span class="dot" aria-hidden="true"></span>
+        <span>AlkindiX</span>
+      </a>
+      <nav class="menu" aria-label="Primary">
+        <a href="/about" class="focus-ring">About</a>
+        <a href="https://proofx.org" class="focus-ring" target="_blank" rel="noopener noreferrer">ProofX</a>
+        <a href="https://architectofsilence.com" class="focus-ring" target="_blank" rel="noopener noreferrer">Essays</a>
+        <a href="/index.html#projects" class="focus-ring">Projects</a>
+        <a href="/index.html#research" class="focus-ring">Research</a>
+        <a href="/index.html#contact" class="focus-ring">Contact</a>
+      </nav>
+      <div class="row" style="gap:10px;align-items:center">
+        <button class="btn secondary theme-toggle" aria-pressed="false" aria-label="Toggle theme">Theme</button>
+        <div class="menu-btn">
+          <button class="btn secondary" aria-expanded="false" aria-controls="menuPanel" aria-haspopup="dialog" aria-label="Open menu">Menu</button>
+        </div>
+      </div>
+    </div>
+    <div id="menuPanel" class="menu-panel container" role="dialog" aria-modal="false" aria-label="Mobile navigation" hidden>
+      <a href="/about">About</a>
+      <a href="https://proofx.org" target="_blank" rel="noopener noreferrer">ProofX</a>
+      <a href="https://architectofsilence.com" target="_blank" rel="noopener noreferrer">Essays</a>
+      <a href="/index.html#projects">Projects</a>
+      <a href="/index.html#research">Research</a>
+      <a href="/index.html#contact">Contact</a>
+    </div>
+  </header>
+  <main id="main" class="container" style="padding-top:40px;padding-bottom:40px;">
+    <h1>About AlkindiX</h1>
+    <p>AlkindiX is the personal headquarters of <strong>Alkindi</strong> — founder of <a href="https://proofx.org" target="_blank" rel="noopener noreferrer">ProofX</a> and ProjectX. The site showcases research, projects, and long-form writing spanning symbolic logic, theorem synthesis, and high-impact computation.</p>
+    <p>Our mission is to build <em>cognition infrastructure</em>: tooling and programs that help researchers reason about complex systems with clarity and rigor.</p>
+  </main>
+  <footer role="contentinfo">
+    <div class="container" style="display:flex; flex-wrap:wrap; gap:10px; justify-content:space-between; align-items:center;">
+      <div>© <span id="y"></span> AlkindiX. All rights reserved.</div>
+      <nav aria-label="Footer">
+        <div style="display:flex; gap:14px;">
+          <a href="/about">About</a>
+          <a href="/terms">Terms</a>
+          <a href="/privacy">Privacy</a>
+        </div>
+      </nav>
+    </div>
+  </footer>
+  <script type="module" src="/main.js" defer></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
       </a>
 
       <nav class="menu" aria-label="Primary">
+        <a href="/about" class="focus-ring">About</a>
         <a href="https://proofx.org" class="focus-ring" target="_blank" rel="noopener noreferrer">ProofX</a>
         <a href="https://architectofsilence.com" class="focus-ring" target="_blank" rel="noopener noreferrer">Essays</a>
         <a href="#projects" class="focus-ring">Projects</a>
@@ -92,6 +93,7 @@
     </div>
 
     <div id="menuPanel" class="menu-panel container" role="dialog" aria-modal="false" aria-label="Mobile navigation" hidden>
+      <a href="/about">About</a>
       <a href="https://proofx.org" target="_blank" rel="noopener noreferrer">ProofX</a>
       <a href="https://architectofsilence.com" target="_blank" rel="noopener noreferrer">Essays</a>
       <a href="#projects">Projects</a>
@@ -251,9 +253,12 @@
       <div>© <span id="y"></span> AlkindiX. All rights reserved.</div>
       <nav aria-label="Footer">
         <div style="display:flex; gap:14px;">
+          <a href="/about">About</a>
           <a href="https://proofx.org" target="_blank" rel="noopener noreferrer">ProofX</a>
           <a href="https://architectofsilence.com" target="_blank" rel="noopener noreferrer">Essays</a>
           <a href="#projects">Projects</a>
+          <a href="/terms">Terms</a>
+          <a href="/privacy">Privacy</a>
         </div>
       </nav>
     </div>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en-GB" dir="ltr" class="no-js" data-theme="auto">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>Privacy — AlkindiX</title>
+  <meta name="description" content="Privacy policy for AlkindiX." />
+  <link rel="preload" href="/styles.css" as="style" />
+  <link rel="stylesheet" href="/styles.css" media="all" />
+  <link rel="preload" href="/main.js" as="script" />
+</head>
+<body>
+  <div id="offlineBanner" class="offline-banner" hidden role="status" aria-live="polite">You're offline.</div>
+  <a href="#main" class="skip" aria-label="Skip to main content">Skip to content</a>
+  <header class="header" role="banner">
+    <div class="container nav">
+      <a href="/" class="brand focus-ring" aria-label="AlkindiX home">
+        <span class="dot" aria-hidden="true"></span>
+        <span>AlkindiX</span>
+      </a>
+      <nav class="menu" aria-label="Primary">
+        <a href="/about" class="focus-ring">About</a>
+        <a href="https://proofx.org" class="focus-ring" target="_blank" rel="noopener noreferrer">ProofX</a>
+        <a href="https://architectofsilence.com" class="focus-ring" target="_blank" rel="noopener noreferrer">Essays</a>
+        <a href="/index.html#projects" class="focus-ring">Projects</a>
+        <a href="/index.html#research" class="focus-ring">Research</a>
+        <a href="/index.html#contact" class="focus-ring">Contact</a>
+      </nav>
+      <div class="row" style="gap:10px;align-items:center">
+        <button class="btn secondary theme-toggle" aria-pressed="false" aria-label="Toggle theme">Theme</button>
+        <div class="menu-btn">
+          <button class="btn secondary" aria-expanded="false" aria-controls="menuPanel" aria-haspopup="dialog" aria-label="Open menu">Menu</button>
+        </div>
+      </div>
+    </div>
+    <div id="menuPanel" class="menu-panel container" role="dialog" aria-modal="false" aria-label="Mobile navigation" hidden>
+      <a href="/about">About</a>
+      <a href="https://proofx.org" target="_blank" rel="noopener noreferrer">ProofX</a>
+      <a href="https://architectofsilence.com" target="_blank" rel="noopener noreferrer">Essays</a>
+      <a href="/index.html#projects">Projects</a>
+      <a href="/index.html#research">Research</a>
+      <a href="/index.html#contact">Contact</a>
+    </div>
+  </header>
+  <main id="main" class="container" style="padding-top:40px;padding-bottom:40px;">
+    <h1>Privacy Policy</h1>
+    <p>AlkindiX keeps things simple: we do not use cookies or third-party trackers. Form submissions are processed only to respond to your request.</p>
+    <p>For any privacy questions, contact us at <a href="mailto:alkindi.network@gmail.com">alkindi.network@gmail.com</a>.</p>
+  </main>
+  <footer role="contentinfo">
+    <div class="container" style="display:flex; flex-wrap:wrap; gap:10px; justify-content:space-between; align-items:center;">
+      <div>© <span id="y"></span> AlkindiX. All rights reserved.</div>
+      <nav aria-label="Footer">
+        <div style="display:flex; gap:14px;">
+          <a href="/about">About</a>
+          <a href="/terms">Terms</a>
+          <a href="/privacy">Privacy</a>
+        </div>
+      </nav>
+    </div>
+  </footer>
+  <script type="module" src="/main.js" defer></script>
+</body>
+</html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -3,9 +3,9 @@
 // Basic offline caching and navigation fallback.
 // ------------------------------------------------------------
 
-const CACHE = 'ax-v1';
+const CACHE = 'ax-v2';
 const OFFLINE_URL = '/offline.html';
-const ASSETS = ['/', OFFLINE_URL, '/styles.css', '/main.js'];
+const ASSETS = ['/', OFFLINE_URL, '/styles.css', '/main.js', '/about', '/terms', '/privacy'];
 
 self.addEventListener('install', event => {
   event.waitUntil(

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,44 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-
-  <!-- Homepage -->
   <url>
     <loc>https://alkindix.com/</loc>
-    <lastmod>2025-08-21</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
-
-  <!-- About Page -->
   <url>
     <loc>https://alkindix.com/about</loc>
-    <lastmod>2025-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
-
-  <!-- Projects -->
   <url>
-    <loc>https://alkindix.com/projects</loc>
-    <lastmod>2025-08-21</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
+    <loc>https://alkindix.com/terms</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
   </url>
-
-  <!-- Blog Index -->
   <url>
-    <loc>https://alkindix.com/blog</loc>
-    <lastmod>2025-08-21</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <loc>https://alkindix.com/privacy</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
   </url>
-
-  <!-- Example Blog Post -->
-  <url>
-    <loc>https://alkindix.com/blog/first-post</loc>
-    <lastmod>2025-08-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
 </urlset>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en-GB" dir="ltr" class="no-js" data-theme="auto">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>Terms — AlkindiX</title>
+  <meta name="description" content="Terms of use for AlkindiX." />
+  <link rel="preload" href="/styles.css" as="style" />
+  <link rel="stylesheet" href="/styles.css" media="all" />
+  <link rel="preload" href="/main.js" as="script" />
+</head>
+<body>
+  <div id="offlineBanner" class="offline-banner" hidden role="status" aria-live="polite">You're offline.</div>
+  <a href="#main" class="skip" aria-label="Skip to main content">Skip to content</a>
+  <header class="header" role="banner">
+    <div class="container nav">
+      <a href="/" class="brand focus-ring" aria-label="AlkindiX home">
+        <span class="dot" aria-hidden="true"></span>
+        <span>AlkindiX</span>
+      </a>
+      <nav class="menu" aria-label="Primary">
+        <a href="/about" class="focus-ring">About</a>
+        <a href="https://proofx.org" class="focus-ring" target="_blank" rel="noopener noreferrer">ProofX</a>
+        <a href="https://architectofsilence.com" class="focus-ring" target="_blank" rel="noopener noreferrer">Essays</a>
+        <a href="/index.html#projects" class="focus-ring">Projects</a>
+        <a href="/index.html#research" class="focus-ring">Research</a>
+        <a href="/index.html#contact" class="focus-ring">Contact</a>
+      </nav>
+      <div class="row" style="gap:10px;align-items:center">
+        <button class="btn secondary theme-toggle" aria-pressed="false" aria-label="Toggle theme">Theme</button>
+        <div class="menu-btn">
+          <button class="btn secondary" aria-expanded="false" aria-controls="menuPanel" aria-haspopup="dialog" aria-label="Open menu">Menu</button>
+        </div>
+      </div>
+    </div>
+    <div id="menuPanel" class="menu-panel container" role="dialog" aria-modal="false" aria-label="Mobile navigation" hidden>
+      <a href="/about">About</a>
+      <a href="https://proofx.org" target="_blank" rel="noopener noreferrer">ProofX</a>
+      <a href="https://architectofsilence.com" target="_blank" rel="noopener noreferrer">Essays</a>
+      <a href="/index.html#projects">Projects</a>
+      <a href="/index.html#research">Research</a>
+      <a href="/index.html#contact">Contact</a>
+    </div>
+  </header>
+  <main id="main" class="container" style="padding-top:40px;padding-bottom:40px;">
+    <h1>Terms of Use</h1>
+    <p>By accessing AlkindiX, you agree to use the site responsibly. Content is provided “as is” without warranties. Projects and research mentioned are offered for informational purposes and may change without notice.</p>
+    <p>If you have questions about these terms, contact us at <a href="mailto:alkindi.network@gmail.com">alkindi.network@gmail.com</a>.</p>
+  </main>
+  <footer role="contentinfo">
+    <div class="container" style="display:flex; flex-wrap:wrap; gap:10px; justify-content:space-between; align-items:center;">
+      <div>© <span id="y"></span> AlkindiX. All rights reserved.</div>
+      <nav aria-label="Footer">
+        <div style="display:flex; gap:14px;">
+          <a href="/about">About</a>
+          <a href="/terms">Terms</a>
+          <a href="/privacy">Privacy</a>
+        </div>
+      </nav>
+    </div>
+  </footer>
+  <script type="module" src="/main.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add About, Terms, and Privacy pages with shared header and footer
- link new pages in navigation and footer
- cache informational pages in service worker and update sitemap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af6b04ffb08328b637690ff257c315